### PR TITLE
Fix deprecated Twitter Card type

### DIFF
--- a/lib/ssr-template.js
+++ b/lib/ssr-template.js
@@ -23,7 +23,7 @@ module.exports = ssrString => `<!DOCTYPE html>
     <meta property="og:image:type" content="image/png" />
     <meta property="og:image:alt" content="${title}" />
   
-    <meta property="twitter:card" content="photo" />
+    <meta property="twitter:card" content="summary_large_image" />
     <meta property="twitter:title" content="${title}" />
     <meta property="twitter:image" content="/assets/card.png" />
     <meta property="twitter:creator" content="@jasonetco" />

--- a/lib/ssr-template.js
+++ b/lib/ssr-template.js
@@ -25,7 +25,7 @@ module.exports = ssrString => `<!DOCTYPE html>
   
     <meta property="twitter:card" content="summary_large_image" />
     <meta property="twitter:title" content="${title}" />
-    <meta property="twitter:image" content="/assets/card.png" />
+    <meta property="twitter:image" content="https://todo.jasonet.co/assets/card.png" />
     <meta property="twitter:creator" content="@jasonetco" />
     <meta property="twitter:description" content="${description}" />
     <meta property="twitter:image:alt" content="${title}" />


### PR DESCRIPTION
The photo cards were [deprecated back in 2015](https://twittercommunity.com/t/deprecating-the-photo-gallery-and-product-cards/38961) unfortunately. Viewers eyes shouldn't bleed when you send this in private messages now :finnadie: ⇒ :godmode: 

<p align="center">
<img width="50%" alt="screen shot 2017-10-02 at 1 19 02 pm" src="https://user-images.githubusercontent.com/121322/31097448-29904b00-a774-11e7-8e89-f8ba75f3bca9.png">
</p>

Cheers,
&nbsp;&nbsp; Lee 🍻 

<sup><strong>PS:</strong> Have I told you how awesome this things is?!?</sup>