### PR TITLE
Remove redundant assertions

### DIFF
--- a/__tests__/lib/commit-is-in-pr.js
+++ b/__tests__/lib/commit-is-in-pr.js
@@ -19,7 +19,6 @@ const makeContext = (ref = 'refs/heads/master', prs = prArr) => ({
 describe('commit-is-in-pr', () => {
   it('returns a PR number if found', async () => {
     const pr = await commitIsInPR(makeContext())
-    expect(typeof pr).toBe('number')
     expect(pr).toBe(10)
   })
 

--- a/__tests__/lib/generate-blob-link.js
+++ b/__tests__/lib/generate-blob-link.js
@@ -22,7 +22,6 @@ describe('generate-blob-link', () => {
     const title = 'example'
     const contents = '\n\n@todo example\n\na\na\na\n\na\na'
     const blobLink = generateBlobLink(context, 'index.js', contents, title, payloads.basic.payload.head_commit.id, config)
-    expect(typeof blobLink).toBe('string')
     expect(blobLink).toBe('https://github.com/JasonEtco/test/blob/f7d286aa6381bbb5045288496403d9427b0746e2/index.js#L3-L5')
   })
 })

--- a/__tests__/lib/generate-body.js
+++ b/__tests__/lib/generate-body.js
@@ -30,8 +30,6 @@ describe('generate-body', () => {
   it('generates a body string', () => {
     const config = { keyword: '@todo', blobLines: 2 }
     const body = generateBody(context, config, title, file, contents, author, sha)
-
-    expect(typeof body).toBe('string')
     expect(body).toBe(fs.readFileSync(path.join(__dirname, '..', 'fixtures', 'bodies', 'default.txt'), 'utf8'))
   })
 
@@ -39,32 +37,24 @@ describe('generate-body', () => {
     it('prepares a message with the committer', () => {
       const config = { keyword: '@todo', autoAssign: true, blobLines: 2 }
       const body = generateBody(context, config, title, file, contents, author, sha)
-
-      expect(typeof body).toBe('string')
       expect(body).toBe(fs.readFileSync(path.join(__dirname, '..', 'fixtures', 'bodies', 'default.txt'), 'utf8'))
     })
 
     it('prepares a message without an assignee', () => {
       const config = { keyword: '@todo', autoAssign: false, blobLines: 2 }
       const body = generateBody(context, config, title, file, contents, author, sha, 10)
-
-      expect(typeof body).toBe('string')
       expect(body).toBe(fs.readFileSync(path.join(__dirname, '..', 'fixtures', 'bodies', 'autoAssignFalse.txt'), 'utf8'))
     })
 
     it('prepares a message with the configured assignee', () => {
       const config = { keyword: '@todo', autoAssign: '@matchai', blobLines: 2 }
       const body = generateBody(context, config, title, file, contents, author, sha, 10)
-
-      expect(typeof body).toBe('string')
       expect(body).toBe(fs.readFileSync(path.join(__dirname, '..', 'fixtures', 'bodies', 'autoAssignString.txt'), 'utf8'))
     })
 
     it('prepares a message with the configured assignees', () => {
       const config = { keyword: '@todo', autoAssign: ['@JasonEtco', 'matchai', 'defunkt'], blobLines: 2 }
       const body = generateBody(context, config, title, file, contents, author, sha, 10)
-
-      expect(typeof body).toBe('string')
       expect(body).toBe(fs.readFileSync(path.join(__dirname, '..', 'fixtures', 'bodies', 'autoAssignArr.txt'), 'utf8'))
     })
   })
@@ -72,8 +62,6 @@ describe('generate-body', () => {
   it('generates a body string with a PR', () => {
     const config = { keyword: '@todo', blobLines: 5 }
     const body = generateBody(context, config, title, file, contents, author, sha, 10)
-
-    expect(typeof body).toBe('string')
     expect(body).toBe(fs.readFileSync(path.join(__dirname, '..', 'fixtures', 'bodies', 'pr.txt'), 'utf8'))
   })
 
@@ -81,16 +69,12 @@ describe('generate-body', () => {
     it('generates a body string without a blob, blobLines: false', () => {
       const config = { keyword: '@todo', blobLines: false }
       const body = generateBody(context, config, title, file, contents, author, sha)
-
-      expect(typeof body).toBe('string')
       expect(body).toBe(fs.readFileSync(path.join(__dirname, '..', 'fixtures', 'bodies', 'no-blob.txt'), 'utf8'))
     })
 
     it('generates a body string without a blob, blobLines: 0', () => {
       const config = { keyword: '@todo', blobLines: 0 }
       const body = generateBody(context, config, title, file, contents, author, sha)
-
-      expect(typeof body).toBe('string')
       expect(body).toBe(fs.readFileSync(path.join(__dirname, '..', 'fixtures', 'bodies', 'no-blob.txt'), 'utf8'))
     })
   })
@@ -98,16 +82,12 @@ describe('generate-body', () => {
   it('generates a body string with a custom message', () => {
     const config = { keyword: '@todo', blobLines: 2 }
     const body = generateBody(context, config, title, file, contentsBody, author, sha)
-
-    expect(typeof body).toBe('string')
     expect(body).toBe(fs.readFileSync(path.join(__dirname, '..', 'fixtures', 'bodies', 'with-body.txt'), 'utf8'))
   })
 
   it('generates a body string with a custom message but no blob', () => {
     const config = { keyword: '@todo', blobLines: false }
     const body = generateBody(context, config, title, file, contentsBody, author, sha)
-
-    expect(typeof body).toBe('string')
     expect(body).toBe(fs.readFileSync(path.join(__dirname, '..', 'fixtures', 'bodies', 'with-body-no-blob.txt'), 'utf8'))
   })
 })

--- a/__tests__/lib/ssr-template.js
+++ b/__tests__/lib/ssr-template.js
@@ -5,7 +5,6 @@ const ssrTemplate = require('../../lib/ssr-template')
 describe('ssr-template', () => {
   it('returns the correct HTML string', async () => {
     const str = ssrTemplate('hello')
-    expect(typeof str).toBe('string')
     expect(str).toBe(fs.readFileSync(path.join(__dirname, '..', 'fixtures', 'page.html'), 'utf8'))
   })
 })


### PR DESCRIPTION
Thanks to @matchai being aggressive when trying to fix problems unrelated to the ones he was asked to fix, this PR removes redundant `typeof` assertions.