### PR TITLE
Installation event

### DIFF
--- a/__tests__/fixtures/payloads.js
+++ b/__tests__/fixtures/payloads.js
@@ -154,3 +154,18 @@ exports.merge = {
     }
   }
 }
+
+exports.installCreated = {
+  event: 'installation',
+  payload: {
+    action: 'created',
+    installation: {
+      id: 10000
+    },
+    repositories: [
+      { full_name: 'JasonEtco/test' },
+      { full_name: 'JasonEtco/pizza' },
+      { full_name: 'JasonEtco/example' }
+    ]
+  }
+}

--- a/__tests__/fixtures/payloads.js
+++ b/__tests__/fixtures/payloads.js
@@ -155,7 +155,34 @@ exports.merge = {
   }
 }
 
-exports.installCreated = {
+exports.installCreatedOne = {
+  event: 'installation',
+  payload: {
+    action: 'created',
+    installation: {
+      id: 10000
+    },
+    repositories: [
+      { full_name: 'JasonEtco/test' }
+    ]
+  }
+}
+
+exports.installCreatedTwo = {
+  event: 'installation',
+  payload: {
+    action: 'created',
+    installation: {
+      id: 10000
+    },
+    repositories: [
+      { full_name: 'JasonEtco/test' },
+      { full_name: 'JasonEtco/pizza' }
+    ]
+  }
+}
+
+exports.installCreatedThree = {
   event: 'installation',
   payload: {
     action: 'created',

--- a/__tests__/index.js
+++ b/__tests__/index.js
@@ -229,7 +229,17 @@ describe('todo', () => {
     })
 
     it('logs the proper message to the console', async () => {
-      await robot.receive(payloads.installCreated)
+      await robot.receive(payloads.installCreatedOne)
+      expect(robot.log).toHaveBeenCalledWith('todo was just installed on JasonEtco/test.')
+    })
+
+    it('logs the proper message to the console w/ 2 repos', async () => {
+      await robot.receive(payloads.installCreatedTwo)
+      expect(robot.log).toHaveBeenCalledWith('todo was just installed on JasonEtco/test and JasonEtco/pizza.')
+    })
+
+    it('logs the proper message to the console w/ 3 repos', async () => {
+      await robot.receive(payloads.installCreatedThree)
       expect(robot.log).toHaveBeenCalledWith('todo was just installed on JasonEtco/test, JasonEtco/pizza and JasonEtco/example.')
     })
   })

--- a/__tests__/index.js
+++ b/__tests__/index.js
@@ -214,4 +214,23 @@ describe('todo', () => {
     await robot.receive(payloads.merge)
     expect(github.issues.create.mock.calls.length).toBe(0)
   })
+
+  describe('installation', () => {
+    let robotLog
+    const {robot} = gimmeRobot()
+
+    beforeEach(() => {
+      robotLog = robot.log
+      robot.log = jest.fn()
+    })
+
+    afterEach(() => {
+      robot.log = robotLog
+    })
+
+    it('logs the proper message to the console', async () => {
+      await robot.receive(payloads.installCreated)
+      expect(robot.log).toHaveBeenCalledWith('todo was just installed on JasonEtco/test, JasonEtco/pizza and JasonEtco/example.')
+    })
+  })
 })

--- a/index.js
+++ b/index.js
@@ -106,4 +106,13 @@ module.exports = (robot) => {
       })
     })
   })
+
+  robot.on('installation.created', context => {
+    const repos = context.payload.repositories.reduce((prev, repo, i, arr) => {
+      if (i === 0) return prev + repo.full_name
+      if (i === arr.length - 1) return `${prev} and ${repo.full_name}`
+      return `${prev}, ${repo.full_name}`
+    }, '')
+    robot.log(`todo was just installed on ${repos}.`)
+  })
 }


### PR DESCRIPTION
Adds an `'installation'` event handler to log newly installed repos to the console.

Closes #26.