### PR TITLE
Use NPM version of Probot instead of the GitHub repo

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3085,6 +3085,13 @@
         "jsonwebtoken": "7.4.3"
       }
     },
+    "github-webhook-handler": {
+      "version": "github:rvagg/github-webhook-handler#7cfcb5b724a7735f132778cf15245cac8547ff60",
+      "requires": {
+        "bl": "1.1.2",
+        "buffer-equal-constant-time": "1.0.1"
+      }
+    },
     "glob": {
       "version": "7.1.2",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
@@ -5777,7 +5784,9 @@
       "dev": true
     },
     "probot": {
-      "version": "github:probot/probot#e509a99a6537ba404e63f1fef36237c497bb5076",
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/probot/-/probot-0.11.0.tgz",
+      "integrity": "sha512-eCnFn+TmWWN8uYFG5QN7tKo9l0CqVYUzWdGv9moiix7PU35F/T32IZjtrsvfN9hGwQT9O72LOtOgI1e4XJgKHQ==",
       "requires": {
         "bottleneck": "1.16.0",
         "bunyan": "1.8.12",
@@ -5797,15 +5806,6 @@
         "raven": "2.2.1",
         "resolve": "1.4.0",
         "semver": "5.4.1"
-      },
-      "dependencies": {
-        "github-webhook-handler": {
-          "version": "github:rvagg/github-webhook-handler#7cfcb5b724a7735f132778cf15245cac8547ff60",
-          "requires": {
-            "bl": "1.1.2",
-            "buffer-equal-constant-time": "1.0.1"
-          }
-        }
       }
     },
     "process-nextick-args": {

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "collectCoverage": true
   },
   "dependencies": {
-    "probot": "probot/probot"
+    "probot": "^0.11.0"
   },
   "devDependencies": {
     "codecov": "^2.3.0",


### PR DESCRIPTION
Using the `probot/probot` dependency is a little risky, in case there are breaking changes made to the repo but not published to NPM. This PR edits the deps list to use Probot from the npm registry.