### PR TITLE
Reopen closed issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ todo:
 | blobLines | `number` or `false` | The number of lines of code to show, starting from the keyword. | 5 |
 | caseSensitive | `boolean` | Should the keyword be case sensitive? | false |
 | label | `boolean`, `string`, `string[]` | Add a label to the new issue. If true, add the `todo` label. If false, don't add any label. You can also give it a label name or an array of label names. | true |
+| reopenClosed | `boolean` | If an issue already exists and is closed, reopen it. Note: if set to false, no new issue will be created. | true |
 
 ## Setup
 

--- a/__tests__/fixtures/bodies/reopen.txt
+++ b/__tests__/fixtures/bodies/reopen.txt
@@ -1,3 +1,3 @@
-This issue has been reopened because the `@todo` comment still exists in `index.js`, as of `sha`.
+This issue has been reopened because the `@todo` comment still exists in `index.js`, as of sha.
 
 If this was not intentional, just remove the comment from your code. You can also set the [`reopenClosed`](https://github.com/JasonEtco/todo#configuring-for-your-project) config if you don't want this to happen at all anymore.

--- a/__tests__/fixtures/bodies/reopen.txt
+++ b/__tests__/fixtures/bodies/reopen.txt
@@ -1,3 +1,5 @@
-This issue has been reopened because the `@todo` comment still exists in [index.js](https://github.com/JasonEtco/test/blob/sha/index.js), as of sha.
+This issue has been reopened because the **`@todo`** comment still exists in [**index.js**](https://github.com/JasonEtco/test/blob/sha/index.js), as of sha.
 
-If this was not intentional, just remove the comment from your code. You can also set the [`reopenClosed`](https://github.com/JasonEtco/todo#configuring-for-your-project) config if you don't want this to happen at all anymore.
+---
+
+###### If this was not intentional, just remove the comment from your code. You can also set the [`reopenClosed`](https://github.com/JasonEtco/todo#configuring-for-your-project) config if you don't want this to happen at all anymore.

--- a/__tests__/fixtures/bodies/reopen.txt
+++ b/__tests__/fixtures/bodies/reopen.txt
@@ -1,0 +1,3 @@
+This issue has been reopened because the `@todo` comment still exists in `index.js`, as of `sha`.
+
+If this was not intentional, just remove the comment from your code. You can also set the [`reopenClosed`](https://github.com/JasonEtco/todo#configuring-for-your-project) config if you don't want this to happen at all anymore.

--- a/__tests__/fixtures/bodies/reopen.txt
+++ b/__tests__/fixtures/bodies/reopen.txt
@@ -1,3 +1,3 @@
-This issue has been reopened because the `@todo` comment still exists in `index.js`, as of sha.
+This issue has been reopened because the `@todo` comment still exists in [index.js](https://github.com/JasonEtco/test/blob/sha/index.js), as of sha.
 
 If this was not intentional, just remove the comment from your code. You can also set the [`reopenClosed`](https://github.com/JasonEtco/todo#configuring-for-your-project) config if you don't want this to happen at all anymore.

--- a/__tests__/fixtures/configs/reopenClosedFalse.yml
+++ b/__tests__/fixtures/configs/reopenClosedFalse.yml
@@ -1,0 +1,3 @@
+todo:
+  keyword: "@todo"
+  reopenClosed: false

--- a/__tests__/index.js
+++ b/__tests__/index.js
@@ -4,7 +4,7 @@ const app = require('..')
 const fs = require('fs')
 const path = require('path')
 
-function gimmeRobot (config = 'basic.yml', issues = [{ data: [{ title: 'An issue that exists', state: 'open', body: `\n\n<!-- probot = {"10000":{"title": "An issue that exists"}} -->` }] }]) {
+function gimmeRobot (config = 'basic.yml', issues = [{ data: [{ title: 'An issue that exists', state: 'open', body: `\n\n<!-- probot = {"10000":{"title": "An issue that exists","file": "index.js"}} -->` }] }]) {
   const cfg = config ? fs.readFileSync(path.join(__dirname, 'fixtures', 'configs', config), 'utf8') : config
   let robot
   let github
@@ -17,7 +17,9 @@ function gimmeRobot (config = 'basic.yml', issues = [{ data: [{ title: 'An issue
     issues: {
       getForRepo: jest.fn().mockReturnValue(Promise.resolve(issues)),
       create: jest.fn(),
-      createLabel: jest.fn()
+      createLabel: jest.fn(),
+      edit: jest.fn(),
+      createComment: jest.fn()
     },
     paginate: jest.fn().mockReturnValue(Promise.resolve(issues)),
     repos: {
@@ -137,7 +139,7 @@ describe('todo', () => {
     expect(github.issues.create.mock.calls.length).toBe(0)
   })
 
-  it('does not create an issues that already exists', async () => {
+  it('does not create an issue that already exists', async () => {
     const {robot, github} = gimmeRobot('existing.yml')
     await robot.receive(payloads.complex)
     expect(github.issues.create.mock.calls.length).toBe(0)
@@ -164,8 +166,8 @@ describe('todo', () => {
   })
 
   it('paginates when there are over 30 issues and does not make them', async () => {
-    const issuesPageOne = Array.apply(null, Array(30)).map((v, i) => ({ title: `I exist ${i}`, state: 'open', body: `\n\n<!-- probot = {"10000":{"title": "I exist ${i}"}} -->` }))
-    const issuesPageTwo = Array.apply(null, Array(2)).map((v, i) => ({ title: `I exist ${i + 30}`, state: 'open', body: `\n\n<!-- probot = {"10000":{"title": "I exist ${i + 30}"}} -->` }))
+    const issuesPageOne = Array.apply(null, Array(30)).map((v, i) => ({ title: `I exist ${i}`, state: 'open', body: `\n\n<!-- probot = {"10000":{"title": "I exist ${i}","file": "many.js"}} -->` }))
+    const issuesPageTwo = Array.apply(null, Array(2)).map((v, i) => ({ title: `I exist ${i + 30}`, state: 'open', body: `\n\n<!-- probot = {"10000":{"title": "I exist ${i + 30}","file": "many.js"}} -->` }))
     const {robot, github} = gimmeRobot('basic.yml', [{ data: issuesPageOne }, { data: issuesPageTwo }])
     await robot.receive(payloads.many)
     expect(github.issues.create.mock.calls.length).toBe(1)
@@ -196,6 +198,40 @@ describe('todo', () => {
     const {robot, github} = gimmeRobot()
     await robot.receive(payloads.merge)
     expect(github.issues.create.mock.calls.length).toBe(0)
+  })
+
+  it('reopens a closed issue', async () => {
+    const issues = [{data: [{
+      title: 'An issue that exists',
+      state: 'open',
+      body: `\n\n<!-- probot = {"10000":{"title": "An issue that exists","file": "index.js"}} -->`
+    }, {
+      title: 'Jason!',
+      state: 'closed',
+      body: `\n\n<!-- probot = {"10000":{"title": "Jason!","file": "index.js"}} -->`
+    }]}]
+    const {robot, github} = gimmeRobot('basic.yml', issues)
+    await robot.receive(payloads.basic)
+    expect(github.issues.edit).toHaveBeenCalledTimes(1)
+    expect(github.issues.createComment).toHaveBeenCalledTimes(1)
+    expect(github.issues.create).toHaveBeenCalledTimes(0)
+  })
+
+  it('respects the reopenClosed config', async () => {
+    const issues = [{data: [{
+      title: 'An issue that exists',
+      state: 'open',
+      body: `\n\n<!-- probot = {"10000":{"title": "An issue that exists","file": "index.js"}} -->`
+    }, {
+      title: 'Jason!',
+      state: 'closed',
+      body: `\n\n<!-- probot = {"10000":{"title": "Jason!","file": "index.js"}} -->`
+    }]}]
+    const {robot, github} = gimmeRobot('reopenClosedFalse.yml', issues)
+    await robot.receive(payloads.basic)
+    expect(github.issues.edit).toHaveBeenCalledTimes(0)
+    expect(github.issues.createComment).toHaveBeenCalledTimes(0)
+    expect(github.issues.create).toHaveBeenCalledTimes(0)
   })
 
   describe('installation', () => {

--- a/__tests__/lib/reopen-closed.js
+++ b/__tests__/lib/reopen-closed.js
@@ -5,6 +5,7 @@ const path = require('path')
 
 describe('reopen-closed', () => {
   const config = {reopenClosed: true, keyword: '@todo'}
+  const log = jest.fn()
   let context
 
   beforeEach(() => {
@@ -24,7 +25,7 @@ describe('reopen-closed', () => {
   })
 
   it('reopens a closed issue', async () => {
-    await reopenClosed(context, config, 3, 'index.js', 'sha')
+    await reopenClosed(log, context, config, 3, 'index.js', 'sha')
     expect(context.github.issues.createComment).toHaveBeenCalledTimes(1)
     expect(context.github.issues.createComment).toHaveBeenLastCalledWith({
       repo: 'test',

--- a/__tests__/lib/reopen-closed.js
+++ b/__tests__/lib/reopen-closed.js
@@ -1,0 +1,36 @@
+const reopenClosed = require('../../lib/reopen-closed')
+const payloads = require('../fixtures/payloads')
+const fs = require('fs')
+const path = require('path')
+
+describe('reopen-closed', () => {
+  const config = {reopenClosed: true, keyword: '@todo'}
+  let context
+
+  beforeEach(() => {
+    context = {
+      repo: (obj) => ({
+        owner: payloads.basic.payload.repository.owner.login,
+        repo: payloads.basic.payload.repository.name,
+        ...obj
+      }),
+      github: {
+        issues: {
+          edit: jest.fn(),
+          createComment: jest.fn()
+        }
+      }
+    }
+  })
+
+  it('reopens a closed issue', async () => {
+    await reopenClosed(context, config, 3, 'index.js', 'sha')
+    expect(context.github.issues.createComment).toHaveBeenCalledTimes(1)
+    expect(context.github.issues.createComment).toHaveBeenLastCalledWith({
+      repo: 'test',
+      owner: 'JasonEtco',
+      number: 3,
+      body: fs.readFileSync(path.join(__dirname, '..', 'fixtures', 'bodies', 'reopen.txt'), 'utf8')
+    })
+  })
+})

--- a/index.js
+++ b/index.js
@@ -3,6 +3,7 @@ const getContents = require('./lib/get-file-contents')
 const generateBody = require('./lib/generate-body')
 const commitIsInPR = require('./lib/commit-is-in-pr')
 const generateLabel = require('./lib/generate-label')
+const reopenClosed = require('./lib/reopen-closed')
 const metadata = require('./lib/metadata')
 
 module.exports = (robot) => {
@@ -13,7 +14,7 @@ module.exports = (robot) => {
     const cfg = config && config.todo ? {...defaultConfig, ...config.todo} : defaultConfig
 
     const [issuePages, labels] = await Promise.all([
-      context.github.paginate(context.github.issues.getForRepo(context.repo())),
+      context.github.paginate(context.github.issues.getForRepo(context.repo({state: 'all'}))),
       generateLabel(context, cfg)
     ])
 
@@ -55,15 +56,20 @@ module.exports = (robot) => {
         const titles = matches.map(title => title.replace(new RegExp(`${cfg.keyword} `, regexFlags), ''))
         titles.forEach(async title => {
           // Check if an issue with that title exists
-          const issueExists = issues.some(issue => {
+          const existingIssue = issues.find(issue => {
             if (!issue.body) return false
-            const key = metadata(context, issue).get('title')
-            return key === title
+            const titleKey = metadata(context, issue).get('title')
+            const fileKey = metadata(context, issue).get('file')
+            return titleKey === title && fileKey === file
           })
 
-          if (issueExists) return
-
-          // :TODO: Reopen existing but closed issues if the same todo is introduced
+          if (existingIssue) {
+            if (cfg.reopenClosed && existingIssue.state === 'closed') {
+              return reopenClosed(context, config, existingIssue.number, file, sha)
+            } else {
+              return
+            }
+          }
 
           const pr = await commitIsInPR(context, sha)
           const body = generateBody(context, cfg, title, file, contents, author, sha, pr)

--- a/index.js
+++ b/index.js
@@ -65,7 +65,7 @@ module.exports = (robot) => {
 
           if (existingIssue) {
             if (cfg.reopenClosed && existingIssue.state === 'closed') {
-              return reopenClosed(context, config, existingIssue.number, file, sha)
+              return reopenClosed(robot.log, context, cfg, existingIssue.number, file, sha)
             } else {
               return
             }

--- a/lib/default-config.js
+++ b/lib/default-config.js
@@ -3,5 +3,6 @@ module.exports = {
   keyword: '@todo',
   blobLines: 5,
   caseSensitive: false,
-  label: true
+  label: true,
+  reopenClosed: true
 }

--- a/lib/reopen-closed.js
+++ b/lib/reopen-closed.js
@@ -10,9 +10,11 @@
 module.exports = async (log, context, config, number, file, sha) => {
   const issue = context.repo({number})
   const link = `https://github.com/${issue.owner}/${issue.repo}/blob/${sha}/${file}`
-  const body = `This issue has been reopened because the \`${config.keyword}\` comment still exists in [${file}](${link}), as of ${sha}.
+  const body = `This issue has been reopened because the **\`${config.keyword}\`** comment still exists in [**${file}**](${link}), as of ${sha}.
 
-If this was not intentional, just remove the comment from your code. You can also set the [\`reopenClosed\`](https://github.com/JasonEtco/todo#configuring-for-your-project) config if you don't want this to happen at all anymore.`
+---
+  
+###### If this was not intentional, just remove the comment from your code. You can also set the [\`reopenClosed\`](https://github.com/JasonEtco/todo#configuring-for-your-project) config if you don't want this to happen at all anymore.`
 
   // Change issue to open
   await context.github.issues.edit({...issue, state: 'open'})

--- a/lib/reopen-closed.js
+++ b/lib/reopen-closed.js
@@ -8,12 +8,13 @@
  * @param {string} sha - SHA of the commit
  */
 module.exports = async (log, context, config, number, file, sha) => {
-  const body = `This issue has been reopened because the \`${config.keyword}\` comment still exists in \`${file}\`, as of ${sha}.
+  const issue = context.repo({number})
+  const link = `https://github.com/${issue.owner}/${issue.repo}/blob/${sha}/${file}`
+  const body = `This issue has been reopened because the \`${config.keyword}\` comment still exists in [${file}](${link}), as of ${sha}.
 
 If this was not intentional, just remove the comment from your code. You can also set the [\`reopenClosed\`](https://github.com/JasonEtco/todo#configuring-for-your-project) config if you don't want this to happen at all anymore.`
 
   // Change issue to open
-  const issue = context.repo({number})
   await context.github.issues.edit({...issue, state: 'open'})
 
   // Post the comment

--- a/lib/reopen-closed.js
+++ b/lib/reopen-closed.js
@@ -13,7 +13,7 @@ module.exports = async (log, context, config, number, file, sha) => {
   const body = `This issue has been reopened because the **\`${config.keyword}\`** comment still exists in [**${file}**](${link}), as of ${sha}.
 
 ---
-  
+
 ###### If this was not intentional, just remove the comment from your code. You can also set the [\`reopenClosed\`](https://github.com/JasonEtco/todo#configuring-for-your-project) config if you don't want this to happen at all anymore.`
 
   // Change issue to open

--- a/lib/reopen-closed.js
+++ b/lib/reopen-closed.js
@@ -1,0 +1,20 @@
+/**
+ * Reopen a closed issue and post a comment saying what happened and why
+ * @param {object} context - Probot context object
+ * @param {object} config - Config object
+ * @param {number} number - Issue number
+ * @param {string} file - File name
+ * @param {string} sha - SHA of the commit
+ */
+module.exports = async (context, config, number, file, sha) => {
+  const body = `This issue has been reopened because the \`${config.keyword}\` comment still exists in \`${file}\`, as of \`${sha}\`.
+
+If this was not intentional, just remove the comment from your code. You can also set the [\`reopenClosed\`](https://github.com/JasonEtco/todo#configuring-for-your-project) config if you don't want this to happen at all anymore.`
+
+  // Change issue to open
+  const issue = context.repo({number})
+  await context.github.issues.edit({...issue, state: 'open'})
+
+  // Post the comment
+  return context.github.issues.createComment({...issue, body})
+}

--- a/lib/reopen-closed.js
+++ b/lib/reopen-closed.js
@@ -1,13 +1,14 @@
 /**
  * Reopen a closed issue and post a comment saying what happened and why
+ * @param {function} log - robot.log()
  * @param {object} context - Probot context object
  * @param {object} config - Config object
  * @param {number} number - Issue number
  * @param {string} file - File name
  * @param {string} sha - SHA of the commit
  */
-module.exports = async (context, config, number, file, sha) => {
-  const body = `This issue has been reopened because the \`${config.keyword}\` comment still exists in \`${file}\`, as of \`${sha}\`.
+module.exports = async (log, context, config, number, file, sha) => {
+  const body = `This issue has been reopened because the \`${config.keyword}\` comment still exists in \`${file}\`, as of ${sha}.
 
 If this was not intentional, just remove the comment from your code. You can also set the [\`reopenClosed\`](https://github.com/JasonEtco/todo#configuring-for-your-project) config if you don't want this to happen at all anymore.`
 
@@ -16,5 +17,6 @@ If this was not intentional, just remove the comment from your code. You can als
   await context.github.issues.edit({...issue, state: 'open'})
 
   // Post the comment
+  log(`Reopening: #${number} in ${issue.owner}/${issue.repo}`)
   return context.github.issues.createComment({...issue, body})
 }


### PR DESCRIPTION
This PR adds functionality to reopen closed issues if the same todo is found in a newly pushed file. It comes with a `reopenClosed` config, whose default is `true`.

Closes #33.