### PR TITLE
Update Travis badge to only show the status of master branch builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# [todo](https://todo.jasonet.co) &middot; [![Build Status](https://img.shields.io/travis/JasonEtco/todo.svg)](https://travis-ci.org/JasonEtco/todo) [![Codecov](https://img.shields.io/codecov/c/github/JasonEtco/todo.svg)](https://codecov.io/gh/JasonEtco/todo/)
+# [todo](https://todo.jasonet.co) &middot; [![Build Status](https://img.shields.io/travis/JasonEtco/todo/master.svg)](https://travis-ci.org/JasonEtco/todo) [![Codecov](https://img.shields.io/codecov/c/github/JasonEtco/todo.svg)](https://codecov.io/gh/JasonEtco/todo/)
 
 > A GitHub App built with [Probot](https://github.com/probot/probot) that creates new issues based on actionable comments in your code.
 


### PR DESCRIPTION
Looks like the Travis badge is showing the status of the last build on this repo, rather than just master branch builds! 😳