### PR TITLE
Remove file key check

### DIFF
--- a/lib/check-for-duplicate-issue.js
+++ b/lib/check-for-duplicate-issue.js
@@ -9,9 +9,7 @@ module.exports = async (context, cfg, title, file) => {
   if (search.data.total_count !== 0) {
     const existingIssue = search.data.items.find(issue => {
       if (!issue.body) return false
-      const titleKey = metadata(context, issue).get('title')
-      const fileKey = metadata(context, issue).get('file')
-      return titleKey === title && fileKey === file
+      return metadata(context, issue).get('title') === title
     })
 
     if (existingIssue) {

--- a/lib/open-issues.js
+++ b/lib/open-issues.js
@@ -65,9 +65,7 @@ module.exports = async (context, robot) => {
 
           // Get comments on the pull request (via the issues API)
           const existingPRComment = todoComments.some(comment => {
-            const titleKey = metadata(context, comment).get('title')
-            const fileKey = metadata(context, comment).get('file')
-            return titleKey === title && fileKey === file
+            return metadata(context, comment).get('title') === title
           })
 
           if (existingPRComment) {


### PR DESCRIPTION
There have been too many cases of duplicate issues being created because a `TODO` has been moved from one file to another. This PR removes the file check, so that won't happen any more.