### PR TITLE
Tweak RegEx to add colon

### DIFF
--- a/lib/search-contents-for-titles.js
+++ b/lib/search-contents-for-titles.js
@@ -6,7 +6,7 @@
  */
 module.exports = (contents, cfg, title) => {
   const regexFlags = cfg.caseSensitive ? 'g' : 'gi'
-  const re = new RegExp(`${cfg.keyword}\\s?${title || '(.*)'}`, regexFlags)
+  const re = new RegExp(`${cfg.keyword}:?\\s?${title || '(.*)'}`, regexFlags)
 
   const matches = contents.match(re)
   if (matches) {


### PR DESCRIPTION
Many people will start their todo comments with `KEYWORD:` (note the `:` character). Unfortunately, people usually don't include that in the keywords in the config file (and/or the default is skewed against it), so I've added a check for the `:` character in the RegEx for title parsing.