### PR TITLE
CLI Tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,14 @@ todo:
 | label | `boolean`, `string`, `string[]` | Add a label to the new issue. If true, add the `todo` label. If false, don't add any label. You can also give it a label name or an array of label names. | true |
 | reopenClosed | `boolean` | If an issue already exists and is closed, reopen it. Note: if set to false, no new issue will be created. | true |
 
+## CLI
+
+There is a CLI tool in this repo that you can use to verify that **todo** is working on your commits. This tool will not actually create new issues, but will let you know what issues a commit _would_ create. Follow the setup instructions below, then run:
+
+```
+$ node ./bin/todo -o OWNER -r REPO -s SHA
+```
+
 ## Setup
 
 ```

--- a/bin/todo.js
+++ b/bin/todo.js
@@ -1,0 +1,54 @@
+const prompt = require('prompt')
+const GitHubAPI = require('github')
+const pushHandler = require('../src/push-handler')
+
+const schema = {
+  properties: {
+    owner: {
+      pattern: /^[a-zA-Z\s\-]+$/,
+      message: 'Name must be only letters, spaces, or dashes',
+      required: true
+    },
+    repo: {
+      pattern: /^[a-zA-Z\s\-]+$/,
+      message: 'Name must be only letters, spaces, or dashes',
+      required: true
+    },
+    sha: {
+      required: true
+    }
+  }
+}
+
+prompt.message = ''
+prompt.start()
+prompt.get(schema, async (err, { owner, repo, sha }) => {
+  if (err) console.error(err)
+
+  const github = new GitHubAPI({})
+  github.issues.create = (o) => console.log(o)
+
+  const context = {
+    id: 1,
+    log: console.log,
+    config: (_, obj) => obj,
+    repo: (o) => ({ owner, repo, ...o }),
+    payload: {
+      ref: 'refs/heads/master',
+      repository: {
+        owner,
+        name: repo,
+        master_branch: 'master'
+      },
+      head_commit: {
+        id: sha,
+        author: {
+          username: owner
+        }
+      }
+    },
+    github
+  }
+
+  await pushHandler(context)
+})

--- a/bin/todo.js
+++ b/bin/todo.js
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 
 const program = require('commander')
+const chalk = require('chalk')
 const GitHubAPI = require('github')
 const pushHandler = require('../src/push-handler')
 
@@ -41,7 +42,12 @@ const context = {
 
 pushHandler(context)
   .then(() => {
-    console.log(issues)
+    issues.forEach(issue => {
+      console.log(chalk.gray('---'))
+      console.log(chalk.gray('Title:'), chalk.bold(issue.title))
+      console.log(chalk.gray('Body:\n'), issue.body)
+      console.log(chalk.gray('---'))
+    })
   })
   .catch(e => {
     if (e.code === 404) {

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
   },
   "dependencies": {
     "@google-cloud/logging-bunyan": "^0.7.0",
+    "chalk": "^2.3.1",
     "commander": "^2.14.1",
     "github": "^13.1.0",
     "hbs": "^4.0.1",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,9 @@
       "jest": true
     }
   },
+  "bin": {
+    "todo": "./bin/todo.js"
+  },
   "jest": {
     "modulePathIgnorePatterns": [
       "<rootDir>/tests/fixtures/",
@@ -37,11 +40,11 @@
   },
   "dependencies": {
     "@google-cloud/logging-bunyan": "^0.7.0",
+    "commander": "^2.14.1",
     "github": "^13.1.0",
     "hbs": "^4.0.1",
     "probot": "^5.0.1",
-    "probot-ts": "^4.0.1-typescript",
-    "prompt": "^1.0.0"
+    "probot-ts": "^4.0.1-typescript"
   },
   "devDependencies": {
     "babel-core": "^6.26.0",

--- a/package.json
+++ b/package.json
@@ -37,9 +37,11 @@
   },
   "dependencies": {
     "@google-cloud/logging-bunyan": "^0.7.0",
+    "github": "^13.1.0",
     "hbs": "^4.0.1",
     "probot": "^5.0.1",
-    "probot-ts": "^4.0.1-typescript"
+    "probot-ts": "^4.0.1-typescript",
+    "prompt": "^1.0.0"
   },
   "devDependencies": {
     "babel-core": "^6.26.0",

--- a/src/pull-request-handler.js
+++ b/src/pull-request-handler.js
@@ -39,7 +39,7 @@ module.exports = async context => {
       keyword: parsed.keyword
     }))
 
-    context.log(`Creating comment [${parsed.title}] in [${context.repo().owner}/${context.repo().repo}#${parsed.number}`)
+    context.log(`Creating comment [${parsed.title}] in [${context.repo().owner}/${context.repo().repo}#${parsed.number}]`)
     await context.github.issues.createComment(context.issue({ body }))
   }
 }

--- a/src/pull-request-merged-handler.js
+++ b/src/pull-request-merged-handler.js
@@ -40,7 +40,7 @@ module.exports = async context => {
       body: parsed.body
     }))
 
-    context.log(`Creating issue [${parsed.title}] in [${context.repo().owner}/${context.repo().repo}`)
+    context.log(`Creating issue [${parsed.title}] in [${context.repo().owner}/${context.repo().repo}]`)
     await context.github.issues.create(context.repo({ title: parsed.title, body, labels, ...assignFlow(config, parsed.username) }))
   }
 }

--- a/src/push-handler.js
+++ b/src/push-handler.js
@@ -49,7 +49,7 @@ module.exports = async context => {
       body: parsed.body
     }))
 
-    context.log(`Creating issue [${parsed.title}] in [${context.repo().owner}/${context.repo().repo}`)
+    context.log(`Creating issue [${parsed.title}] in [${context.repo().owner}/${context.repo().repo}]`)
     await context.github.issues.create(context.repo({ title: parsed.title, body, labels, ...assignFlow(config, parsed.username) }))
   }
 }


### PR DESCRIPTION
This PR adds a little CLI tool to verify that issues are being generated as expected. This does not actually open issues, but instead just outputs the object that _would_ be sent to the issues API endpoint. This is mostly for my sake, but might be nice for other people to try out the app's functionality.

### Usage

```
$ node ./bin/todo -o OWNER -r REPO -s SHA
```

### Example

<img width="1010" alt="image" src="https://user-images.githubusercontent.com/10660468/36578736-2675b07a-182d-11e8-8651-892dde54f0b1.png">
