### PR TITLE
Parse diff chunks at a time

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,12 @@ There is a CLI tool in this repo that you can use to verify that **todo** is wor
 $ node ./bin/todo -o OWNER -r REPO -s SHA
 ```
 
+You can also parse a local file instead of a sha:
+
+```
+$ node ./bin/todo -o OWNER -r REPO -f ./path/to/file.txt
+```
+
 ## Setup
 
 ```

--- a/bin/todo.js
+++ b/bin/todo.js
@@ -26,6 +26,7 @@ github.issues.create = issue => issues.push(issue)
 github.search.issues = () => ({ data: { total_count: 0 } })
 
 const context = {
+  event: 'push',
   id: 1,
   log: () => {},
   config: (_, obj) => obj,

--- a/bin/todo.js
+++ b/bin/todo.js
@@ -19,7 +19,7 @@ const { owner, repo, file } = program
 
 const github = new GitHubAPI({})
 if (file) {
-  github.repos.getCommit = () => ({ data: fs.readFileSync(path.resolve(file)) })
+  github.repos.getCommit = () => ({ data: fs.readFileSync(path.resolve(file), 'utf8') })
   github.gitdata.getCommit = () => ({ data: { parents: [] } })
 }
 github.issues.create = issue => issues.push(issue)

--- a/src/pull-request-handler.js
+++ b/src/pull-request-handler.js
@@ -1,45 +1,47 @@
 const handlerSetup = require('./utils/handler-setup')
 const parseDiff = require('./utils/parse-diff')
-const { endDiff } = require('./utils/helpers')
+const chunkDiff = require('./utils/chunk-diff')
 const { comment } = require('./templates')
 
 module.exports = async context => {
   const [
     { regex, config },
     { data: comments },
-    { data: diff }
+    chunks
   ] = await Promise.all([
     handlerSetup(context),
     context.github.issues.getComments(context.issue({})),
-    context.github.pullRequests.get(context.issue({
-      headers: { Accept: 'application/vnd.github.diff' }
-    }))
+    chunkDiff(context)
   ])
 
-  let match
-  while ((match = regex.exec(endDiff(diff))) !== null) {
-    const parsed = parseDiff({ match, context, config })
+  for (let i = 0; i < chunks.length; i++) {
+    const chunk = chunks[i]
 
-    if (parsed.filename === '.github/config.yml') continue
+    let match
+    while ((match = regex.exec(chunk)) !== null) {
+      const parsed = parseDiff({ match, context, config })
 
-    // This PR already has a comment for this item
-    if (comments.some(c => c.body.startsWith(`## ${parsed.title}`))) {
-      context.log(`Comment with title [${parsed.title}] already exists`)
-      continue
+      if (parsed.filename === '.github/config.yml') continue
+
+      // This PR already has a comment for this item
+      if (comments.some(c => c.body.startsWith(`## ${parsed.title}`))) {
+        context.log(`Comment with title [${parsed.title}] already exists`)
+        continue
+      }
+
+      const body = comment(context.repo({
+        title: parsed.title,
+        body: parsed.body,
+        sha: parsed.sha,
+        assignedToString: parsed.assignedToString,
+        number: parsed.number,
+        range: parsed.range,
+        filename: parsed.filename,
+        keyword: parsed.keyword
+      }))
+
+      context.log(`Creating comment [${parsed.title}] in [${context.repo().owner}/${context.repo().repo}#${parsed.number}]`)
+      await context.github.issues.createComment(context.issue({ body }))
     }
-
-    const body = comment(context.repo({
-      title: parsed.title,
-      body: parsed.body,
-      sha: parsed.sha,
-      assignedToString: parsed.assignedToString,
-      number: parsed.number,
-      range: parsed.range,
-      filename: parsed.filename,
-      keyword: parsed.keyword
-    }))
-
-    context.log(`Creating comment [${parsed.title}] in [${context.repo().owner}/${context.repo().repo}#${parsed.number}]`)
-    await context.github.issues.createComment(context.issue({ body }))
   }
 }

--- a/src/pull-request-merged-handler.js
+++ b/src/pull-request-merged-handler.js
@@ -1,46 +1,49 @@
 const parseDiff = require('./utils/parse-diff')
+const chunkDiff = require('./utils/chunk-diff')
 const checkForDuplicateIssue = require('./utils/check-for-duplicate-issue')
 const handlerSetup = require('./utils/handler-setup')
 const reopenClosed = require('./utils/reopen-closed')
-const { assignFlow, endDiff } = require('./utils/helpers')
+const { assignFlow } = require('./utils/helpers')
 const { issueFromMerge } = require('./templates')
 
 module.exports = async context => {
   const [
     { regex, config, labels },
-    { data: diff }
+    chunks
   ] = await Promise.all([
     handlerSetup(context),
-    context.github.pullRequests.get(context.issue({
-      headers: { Accept: 'application/vnd.github.diff' }
-    }))
+    chunkDiff(context)
   ])
 
-  let match
-  while ((match = regex.exec(endDiff(diff))) !== null) {
-    const parsed = parseDiff({ match, context, config })
+  for (let i = 0; i < chunks.length; i++) {
+    const chunk = chunks[i]
 
-    if (parsed.filename === '.github/config.yml') continue
+    let match
+    while ((match = regex.exec(chunk)) !== null) {
+      const parsed = parseDiff({ match, context, config })
 
-    // Prevent duplicates
-    const existingIssue = await checkForDuplicateIssue(context, parsed.title)
-    if (existingIssue) {
-      context.log(`Duplicate issue found with title [${parsed.title}]`)
-      await reopenClosed({ context, config, issue: existingIssue }, parsed)
-      continue
+      if (parsed.filename === '.github/config.yml') continue
+
+      // Prevent duplicates
+      const existingIssue = await checkForDuplicateIssue(context, parsed.title)
+      if (existingIssue) {
+        context.log(`Duplicate issue found with title [${parsed.title}]`)
+        await reopenClosed({ context, config, issue: existingIssue }, parsed)
+        continue
+      }
+
+      const body = issueFromMerge(context.repo({
+        sha: parsed.sha,
+        assignedToString: parsed.assignedToString,
+        range: parsed.range,
+        filename: parsed.filename,
+        keyword: parsed.keyword,
+        number: parsed.number,
+        body: parsed.body
+      }))
+
+      context.log(`Creating issue [${parsed.title}] in [${context.repo().owner}/${context.repo().repo}]`)
+      await context.github.issues.create(context.repo({ title: parsed.title, body, labels, ...assignFlow(config, parsed.username) }))
     }
-
-    const body = issueFromMerge(context.repo({
-      sha: parsed.sha,
-      assignedToString: parsed.assignedToString,
-      range: parsed.range,
-      filename: parsed.filename,
-      keyword: parsed.keyword,
-      number: parsed.number,
-      body: parsed.body
-    }))
-
-    context.log(`Creating issue [${parsed.title}] in [${context.repo().owner}/${context.repo().repo}]`)
-    await context.github.issues.create(context.repo({ title: parsed.title, body, labels, ...assignFlow(config, parsed.username) }))
   }
 }

--- a/src/push-handler.js
+++ b/src/push-handler.js
@@ -1,6 +1,7 @@
 const checkForDuplicateIssue = require('./utils/check-for-duplicate-issue')
 const handlerSetup = require('./utils/handler-setup')
-const { assignFlow, endDiff } = require('./utils/helpers')
+const { assignFlow } = require('./utils/helpers')
+const chunkDiff = require('./utils/chunk-diff')
 const parseDiff = require('./utils/parse-diff')
 const reopenClosed = require('./utils/reopen-closed')
 const { issue } = require('./templates')
@@ -17,39 +18,40 @@ module.exports = async context => {
 
   const [
     { regex, config, labels },
-    { data: diff }
+    chunks
   ] = await Promise.all([
     handlerSetup(context),
-    context.github.repos.getCommit(context.repo({
-      sha: context.payload.head_commit.id,
-      headers: { Accept: 'application/vnd.github.diff' }
-    }))
+    chunkDiff(context)
   ])
 
   let match
-  while ((match = regex.exec(endDiff(diff))) !== null) {
-    const parsed = parseDiff({ match, context, config })
+  for (let i = 0; i < chunks.length; i++) {
+    const chunk = chunks[i]
 
-    if (parsed.filename === '.github/config.yml') continue
+    while ((match = regex.exec(chunk)) !== null) {
+      const parsed = parseDiff({ match, context, config })
 
-    // Prevent duplicates
-    const existingIssue = await checkForDuplicateIssue(context, parsed.title)
-    if (existingIssue) {
-      context.log(`Duplicate issue found with title [${parsed.title}]`)
-      await reopenClosed({ context, config, issue: existingIssue }, parsed)
-      continue
+      if (parsed.filename === '.github/config.yml') continue
+
+      // Prevent duplicates
+      const existingIssue = await checkForDuplicateIssue(context, parsed.title)
+      if (existingIssue) {
+        context.log(`Duplicate issue found with title [${parsed.title}]`)
+        await reopenClosed({ context, config, issue: existingIssue }, parsed)
+        continue
+      }
+
+      const body = issue(context.repo({
+        sha: parsed.sha,
+        assignedToString: parsed.assignedToString,
+        range: parsed.range,
+        filename: parsed.filename,
+        keyword: parsed.keyword,
+        body: parsed.body
+      }))
+
+      context.log(`Creating issue [${parsed.title}] in [${context.repo().owner}/${context.repo().repo}]`)
+      await context.github.issues.create(context.repo({ title: parsed.title, body, labels, ...assignFlow(config, parsed.username) }))
     }
-
-    const body = issue(context.repo({
-      sha: parsed.sha,
-      assignedToString: parsed.assignedToString,
-      range: parsed.range,
-      filename: parsed.filename,
-      keyword: parsed.keyword,
-      body: parsed.body
-    }))
-
-    context.log(`Creating issue [${parsed.title}] in [${context.repo().owner}/${context.repo().repo}]`)
-    await context.github.issues.create(context.repo({ title: parsed.title, body, labels, ...assignFlow(config, parsed.username) }))
   }
 }

--- a/src/utils/chunk-diff.js
+++ b/src/utils/chunk-diff.js
@@ -15,7 +15,8 @@ module.exports = async context => {
   }
 
   const diffWithEnd = endDiff(diff)
-  const reg = /^diff --git\s.+\n[\s\S]+?(?=^diff|\n^__END_OF_DIFF_PARSING__)/gm
+  const reg = /^diff --git\s.+\n[\s\S]+?(?=^diff|^__END_OF_DIFF_PARSING__)/gm
+
   const chunks = []
   let match
   while ((match = reg.exec(diffWithEnd)) !== null) {

--- a/src/utils/chunk-diff.js
+++ b/src/utils/chunk-diff.js
@@ -1,0 +1,26 @@
+const { endDiff } = require('./helpers')
+
+module.exports = async context => {
+  let diff
+
+  if (context.event === 'push') {
+    diff = (await context.github.repos.getCommit(context.repo({
+      sha: context.payload.head_commit.id,
+      headers: { Accept: 'application/vnd.github.diff' }
+    }))).data
+  } else {
+    diff = (await context.github.pullRequests.get(context.issue({
+      headers: { Accept: 'application/vnd.github.diff' }
+    }))).data
+  }
+
+  const diffWithEnd = endDiff(diff)
+  const reg = /^diff --git\s.+\n[\s\S]+?(?=^diff|\n^__END_OF_DIFF_PARSING__)/gm
+  const chunks = []
+  let match
+  while ((match = reg.exec(diffWithEnd)) !== null) {
+    chunks.push(match[0])
+  }
+
+  return chunks
+}

--- a/src/utils/handler-setup.js
+++ b/src/utils/handler-setup.js
@@ -11,7 +11,7 @@ module.exports = async context => {
   const cfg = config && config.todo ? {...defaultConfig, ...config.todo} : defaultConfig
   const labels = await generateLabel(context, cfg)
   const keywords = Array.isArray(cfg.keyword) ? cfg.keyword : [cfg.keyword]
-  const reg = new RegExp(`^diff --git a/.+ b/(.+)[\\s\\S]+?^@{2}.+\\+(\\d+).+@{2}$([\\s\\S]+?(^(\\+).*(${keywords.join('|')})(?:[:-\\s]+)?(.*))[\\s\\S]*?)(?=\\n.*?^diff|\\n.*?^__END_OF_DIFF_PARSING__)`, 'gm')
+  const reg = new RegExp(`^diff --git a/.+ b/(.+)[\\s\\S]+?^@{2}.+\\+(\\d+).+@{2}$([\\s\\S]+?(^(\\+).*(${keywords.join('|')})(?:[:-\\s]+)?\\s(.*))[\\s\\S]+)`, 'gm')
 
   return {
     config: cfg,


### PR DESCRIPTION
Reworks the diff parsing to parse chunks at a time, rather than the whole diff string at once. This is mainly because of a limitation I got to with the RegEx; I wasn't able to stop it from including chunks that were earlier in the diff in matched chunks (that contain `todo`s). That bug (first spotted in #111) made code blobs report the wrong file and line number.

I'd love to find a way to make that RegEx work to avoid more loops, but this is good enough for now.

While getting this to work, I also added a `-f, --file` option to the CLI to run a file through the parser. Handy for testing out user-submitted diffs!

Closes #111 