### PR TITLE
Tweak chunk parser

### DIFF
--- a/index.js
+++ b/index.js
@@ -18,11 +18,13 @@ probot.load(bot)
  */
 exports.bot = (request, response) => {
   const event = request.get('x-github-event') || request.get('X-GitHub-Event')
+  const id = request.get('x-github-delivery') || request.get('X-GitHub-Delivery')
   console.log(`Received event ${event}${request.body.action ? ('.' + request.body.action) : ''}`)
   if (event) {
     try {
       probot.receive({
         event: event,
+        id: id,
         payload: request.body
       }).then(() => {
         response.send({

--- a/src/pull-request-handler.js
+++ b/src/pull-request-handler.js
@@ -1,5 +1,5 @@
 const handlerSetup = require('./utils/handler-setup')
-const parseDiff = require('./utils/parse-diff')
+const parseChunk = require('./utils/parse-chunk')
 const chunkDiff = require('./utils/chunk-diff')
 const { comment } = require('./templates')
 
@@ -19,7 +19,7 @@ module.exports = async context => {
 
     let match
     while ((match = regex.exec(chunk)) !== null) {
-      const parsed = parseDiff({ match, context, config })
+      const parsed = parseChunk({ match, context, config })
 
       if (parsed.filename === '.github/config.yml') continue
 

--- a/src/pull-request-merged-handler.js
+++ b/src/pull-request-merged-handler.js
@@ -1,4 +1,4 @@
-const parseDiff = require('./utils/parse-diff')
+const parseChunk = require('./utils/parse-chunk')
 const chunkDiff = require('./utils/chunk-diff')
 const checkForDuplicateIssue = require('./utils/check-for-duplicate-issue')
 const handlerSetup = require('./utils/handler-setup')
@@ -20,7 +20,7 @@ module.exports = async context => {
 
     let match
     while ((match = regex.exec(chunk)) !== null) {
-      const parsed = parseDiff({ match, context, config })
+      const parsed = parseChunk({ match, context, config })
 
       if (parsed.filename === '.github/config.yml') continue
 

--- a/src/push-handler.js
+++ b/src/push-handler.js
@@ -2,7 +2,7 @@ const checkForDuplicateIssue = require('./utils/check-for-duplicate-issue')
 const handlerSetup = require('./utils/handler-setup')
 const { assignFlow } = require('./utils/helpers')
 const chunkDiff = require('./utils/chunk-diff')
-const parseDiff = require('./utils/parse-diff')
+const parseChunk = require('./utils/parse-chunk')
 const reopenClosed = require('./utils/reopen-closed')
 const { issue } = require('./templates')
 
@@ -29,7 +29,7 @@ module.exports = async context => {
     const chunk = chunks[i]
 
     while ((match = regex.exec(chunk)) !== null) {
-      const parsed = parseDiff({ match, context, config })
+      const parsed = parseChunk({ match, context, config })
 
       if (parsed.filename === '.github/config.yml') continue
 

--- a/src/utils/parse-chunk.js
+++ b/src/utils/parse-chunk.js
@@ -17,6 +17,7 @@ module.exports = ({ match, context, config }) => {
     7: title
   } = match
 
+  context.log(context)
   context.log(`Match found for ${context.event}/${context.id}: ${title}`)
 
   // Get the line number that the matched line is on

--- a/src/utils/parse-chunk.js
+++ b/src/utils/parse-chunk.js
@@ -17,7 +17,6 @@ module.exports = ({ match, context, config }) => {
     7: title
   } = match
 
-  context.log(context)
   context.log(`Match found for ${context.event}/${context.id}: ${title}`)
 
   // Get the line number that the matched line is on


### PR DESCRIPTION
Rename `parse-diff` to `parse-chunk` (because that's what its doing now), and fix the missing `id` property on the context object in the logs.