### PR TITLE
Revert "Update probot-ts to the latest version 🚀"

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "github": "^13.1.0",
     "hbs": "^4.0.1",
     "probot": "^5.0.1",
-    "probot-ts": "^5.0.2-typescript"
+    "probot-ts": "^4.0.1-typescript"
   },
   "devDependencies": {
     "babel-core": "^6.26.0",


### PR DESCRIPTION
Reverts JasonEtco/todo#118 - when I tried to deploy, GCF reported an error because of an `async/await` in Bottleneck:

https://github.com/SGrondin/bottleneck/commit/02db071cb63071db597e1063c68c2fcd4c16d77d