### PR TITLE
Update to octokit rest

### DIFF
--- a/bin/todo.js
+++ b/bin/todo.js
@@ -2,7 +2,7 @@
 
 const program = require('commander')
 const chalk = require('chalk')
-const GitHubAPI = require('github')
+const octokit = require('@octokit/rest')()
 const pushHandler = require('../src/push-handler')
 const fs = require('fs')
 const path = require('path')
@@ -17,13 +17,12 @@ program
 const issues = []
 const { owner, repo, file } = program
 
-const github = new GitHubAPI({})
 if (file) {
-  github.repos.getCommit = () => ({ data: fs.readFileSync(path.resolve(file), 'utf8') })
-  github.gitdata.getCommit = () => ({ data: { parents: [] } })
+  octokit.repos.getCommit = () => ({ data: fs.readFileSync(path.resolve(file), 'utf8') })
+  octokit.gitdata.getCommit = () => ({ data: { parents: [] } })
 }
-github.issues.create = issue => issues.push(issue)
-github.search.issues = () => ({ data: { total_count: 0 } })
+octokit.issues.create = issue => issues.push(issue)
+octokit.search.issues = () => ({ data: { total_count: 0 } })
 
 const context = {
   event: 'push',
@@ -45,7 +44,7 @@ const context = {
       }
     }
   },
-  github
+  github: octokit
 }
 
 pushHandler(context)

--- a/package.json
+++ b/package.json
@@ -41,9 +41,9 @@
   },
   "dependencies": {
     "@google-cloud/logging-bunyan": "^0.7.0",
+    "@octokit/rest": "^15.1.7",
     "chalk": "^2.3.1",
     "commander": "^2.14.1",
-    "github": "^14.0.0",
     "hbs": "^4.0.1",
     "probot": "^5.0.1",
     "probot-ts": "^4.0.1-typescript"


### PR DESCRIPTION
Update the CLI to use `@octokit/rest` instead of `github`, since the latter is now deprecated. Thanks to @gr2m for spotting it, and for everything he does for the Node Octokit library ❤️ 