### PR TITLE
Fixes duplicate comment creation.

### DIFF
--- a/src/pull-request-handler.js
+++ b/src/pull-request-handler.js
@@ -7,11 +7,9 @@ const { lineBreak } = require('./utils/helpers')
 module.exports = async context => {
   const [
     { regex, config },
-    { data: comments },
     chunks
   ] = await Promise.all([
     handlerSetup(context),
-    context.github.issues.getComments(context.issue({})),
     chunkDiff(context)
   ])
 
@@ -29,12 +27,6 @@ module.exports = async context => {
         continue
       } else if (excludePattern && new RegExp(excludePattern).test(parsed.filename)) {
         context.log.debug('Skipping ' + parsed.filename + ' as it matches the exclude pattern ' + excludePattern)
-        continue
-      }
-
-      // This PR already has a comment for this item
-      if (comments.some(c => c.body.startsWith(`## ${parsed.title}`))) {
-        context.log(`Comment with title [${parsed.title}] already exists`)
         continue
       }
 

--- a/src/push-handler.js
+++ b/src/push-handler.js
@@ -18,9 +18,11 @@ module.exports = async context => {
 
   const [
     { regex, config, labels },
+    { data: comments },
     chunks
   ] = await Promise.all([
     handlerSetup(context),
+    context.github.issues.getComments(context.issue({})),
     chunkDiff(context)
   ])
 
@@ -38,6 +40,12 @@ module.exports = async context => {
         continue
       } else if (excludePattern && new RegExp(excludePattern).test(parsed.filename)) {
         context.log.debug('Skipping ' + parsed.filename + ' as it matches the exclude pattern ' + excludePattern)
+        continue
+      }
+
+      // This PR already has a comment for this item
+      if (comments.some(c => c.body.startsWith(`## ${parsed.title}`))) {
+        context.log(`Comment with title [${parsed.title}] already exists`)
         continue
       }
 


### PR DESCRIPTION
Fixes #120 
The code for duplicate comment checking was incorrectly placed in `pull-request-handler` when it should have been present in `push-handler`.
