### PR TITLE
Don't act on closed, unmerged PRs

### DIFF
--- a/lib/pull-request-merged-handler.js
+++ b/lib/pull-request-merged-handler.js
@@ -6,6 +6,9 @@ const mainLoop = require('./utils/main-loop')
 const avoidReplicationLag = require('./utils/avoid-replication-lag')
 
 module.exports = async context => {
+  // Don't act on PRs that were close but not merged
+  if (!context.payload.pull_request.merged) return
+
   context.github.hook.before('request', avoidReplicationLag())
 
   return mainLoop(context, async ({

--- a/tests/pull-request-merge-handler.test.js
+++ b/tests/pull-request-merge-handler.test.js
@@ -11,6 +11,18 @@ describe('pull-request-merged-handler', () => {
     github = gimme.github
   })
 
+  it('does nothing on an unmerged, closed PR', async () => {
+    await app.receive({
+      ...event,
+      payload: {
+        ...event.payload,
+        pull_request: { merged: false }
+      }
+    })
+
+    expect(github.issues.create).not.toHaveBeenCalled()
+  })
+
   it('creates an issue', async () => {
     await app.receive(event)
     expect(github.issues.create).toHaveBeenCalledTimes(1)


### PR DESCRIPTION
This PR adds a small check to the `pull-request-merged-handler`, to ensure that its not doing anything on PRs that have been closed without merging.

Closes #167 