### PR TITLE
Allows : characters in BODY keyword retrieval

### DIFF
--- a/lib/utils/check-for-body.js
+++ b/lib/utils/check-for-body.js
@@ -5,7 +5,7 @@ module.exports = (changes, changeIndex, config) => {
   if (!nextLine) return false
 
   const keywords = Array.isArray(config.bodyKeyword) ? config.bodyKeyword : [config.bodyKeyword]
-  const BODY_REG = new RegExp(`.+()\\s(?<keyword>${keywords.join('|')}):?\\s(?<body>.*)`)
+  const BODY_REG = new RegExp(`.+(?<keyword>${keywords.join('|')}):?\\s(?<body>.*)`)
   const matches = BODY_REG.exec(nextLine.content)
   if (!matches) return false
 

--- a/lib/utils/check-for-body.js
+++ b/lib/utils/check-for-body.js
@@ -5,7 +5,7 @@ module.exports = (changes, changeIndex, config) => {
   if (!nextLine) return false
 
   const keywords = Array.isArray(config.bodyKeyword) ? config.bodyKeyword : [config.bodyKeyword]
-  const BODY_REG = new RegExp(`.+()\\s(?<keyword>${keywords.join('|')})\\s(?<body>.*)`)
+  const BODY_REG = new RegExp(`.+()\\s(?<keyword>${keywords.join('|')}):?\\s(?<body>.*)`)
   const matches = BODY_REG.exec(nextLine.content)
   if (!matches) return false
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -33,9 +33,9 @@
       }
     },
     "@octokit/rest": {
-      "version": "15.1.7",
-      "resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-15.1.7.tgz",
-      "integrity": "sha512-M4lwkd+lZGth6GDc8e/l7TuebWiZv/uwwreqPNqxrfrvPRLiUsHqiAXUH/JoWQ0K7rcqQeh0Mv2KOANJUPwwVA==",
+      "version": "15.18.0",
+      "resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-15.18.0.tgz",
+      "integrity": "sha512-D1dDJMbvT4dok9++vc8uwCr92ndadwfz6vHK+IklzBHKSsuLlhpv2/dzx97Y4aRlm0t74LeXKDp4j0b4M2vmQw==",
       "requires": {
         "before-after-hook": "^1.1.0",
         "btoa-lite": "^1.0.0",
@@ -44,30 +44,27 @@
         "https-proxy-agent": "^2.2.0",
         "lodash": "^4.17.4",
         "node-fetch": "^2.1.1",
+        "universal-user-agent": "^2.0.0",
         "url-template": "^2.0.8"
       },
       "dependencies": {
         "debug": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "version": "3.2.6",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
           "requires": {
-            "ms": "2.0.0"
+            "ms": "^2.1.1"
           }
         },
-        "https-proxy-agent": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-2.2.0.tgz",
-          "integrity": "sha512-uUWcfXHvy/dwfM9bqa6AozvAjS32dZSTUYd/4SEpYKRg6LEcPLshksnQYRudM9AyNvUARMfAg5TLjUDyX/K4vA==",
-          "requires": {
-            "agent-base": "^4.1.0",
-            "debug": "^3.1.0"
-          }
+        "ms": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
         },
         "node-fetch": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.1.1.tgz",
-          "integrity": "sha1-NpynC4L1DIZJYQSmx3bSdPTkotQ="
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.3.0.tgz",
+          "integrity": "sha512-MOd8pV3fxENbryESLgVIeaGKrdl+uaYhCSSVkjeOb/31/njTpcis5aWfdqgNlHIrKOLRbMnfPINPOML2CIFeXA=="
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     ]
   },
   "dependencies": {
-    "@octokit/rest": "^15.1.7",
+    "@octokit/rest": "^15.18.0",
     "chalk": "^2.3.1",
     "commander": "^2.14.1",
     "hbs": "^4.0.1",

--- a/tests/lib/check-for-body.test.js
+++ b/tests/lib/check-for-body.test.js
@@ -1,0 +1,53 @@
+const checkForBody = require('../../lib/utils/check-for-body')
+
+describe('check-for-body', () => {
+  let changes, config
+
+  beforeEach(() => {
+    changes = [{
+      type: 'add',
+      ln: 257,
+      content: '+    // TODO: A title'
+    }, {
+      type: 'add',
+      ln: 258,
+      content: '+    // BODY: A body'
+    }]
+
+    config = {
+      bodyKeyword: 'BODY'
+    }
+  })
+
+  it('returns the body if its present', () => {
+    const actual = checkForBody(changes, 0, config)
+    expect(actual).toBe('A body')
+  })
+
+  it('returns false if there is no next line', () => {
+    const actual = checkForBody([changes[0]], 0, config)
+    expect(actual).toBe(false)
+  })
+
+  it('returns false if the next line does not have a body', () => {
+    changes = [
+      changes[0],
+      { content: '+    // PIZZA' }
+    ]
+
+    const actual = checkForBody(changes, 0, config)
+    expect(actual).toBe(false)
+  })
+
+  it('allows for multiple keywords', () => {
+    config.bodyKeyword = ['PIZZA', 'text']
+
+    changes[1].content = '// PIZZA This is a pizza'
+    const pizza = checkForBody(changes, 0, config)
+    expect(pizza).toBe('This is a pizza')
+
+    changes[1].content = '// text This is a text'
+    const text = checkForBody(changes, 0, config)
+    expect(text).toBe('This is a text')
+  })
+})


### PR DESCRIPTION
In the refactor #165, I inadvertandly removed support for the `:` character when parsing for body keywords. So, this would work:

```diff
+ // BODY Hey!
```

But this would not:

```diff
+ // BODY: Nope!
```

This also pointed out some missing tests so I went ahead and added those.

Fixes #171 