### PR TITLE
Ignore big diffs

### DIFF
--- a/lib/utils/get-diff.js
+++ b/lib/utils/get-diff.js
@@ -1,3 +1,5 @@
+const MAX_SIZE = 2000000
+
 /**
  * Gets the diff of the commit or pull request as a string
  * @param {import('probot').Context} context
@@ -7,15 +9,20 @@ module.exports = async context => {
   let diff
 
   if (context.event === 'push') {
-    diff = (await context.github.repos.getCommit(context.repo({
+    diff = await context.github.repos.getCommit(context.repo({
       sha: context.payload.head_commit.id,
       headers: { Accept: 'application/vnd.github.diff' }
-    }))).data
+    }))
   } else {
-    diff = (await context.github.pulls.get(context.issue({
+    diff = await context.github.pulls.get(context.issue({
       headers: { Accept: 'application/vnd.github.diff' }
-    }))).data
+    }))
   }
 
-  return diff
+  const size = diff.data.length
+  if (size > MAX_SIZE) {
+    throw new Error(`Diff is too large: ${size}/${MAX_SIZE}`)
+  }
+
+  return diff.data
 }

--- a/lib/utils/get-diff.js
+++ b/lib/utils/get-diff.js
@@ -1,6 +1,7 @@
 /**
  * This value will take some tweaking. A really large diff
- * is in the hundred thousands (288421 prompted this change).
+ * is in the hundred thousands (288421 prompted this change),
+ * but they can go way higher and would result in downtime.
  */
 const MAX_DIFF_SIZE = 100000
 

--- a/lib/utils/get-diff.js
+++ b/lib/utils/get-diff.js
@@ -1,4 +1,4 @@
-const MAX_SIZE = 2000000
+const MAX_SIZE = 1000000
 
 /**
  * Gets the diff of the commit or pull request as a string

--- a/lib/utils/get-diff.js
+++ b/lib/utils/get-diff.js
@@ -21,7 +21,8 @@ module.exports = async context => {
 
   const size = diff.data.length
   if (size > MAX_SIZE) {
-    throw new Error(`Diff is too large: ${size}/${MAX_SIZE}`)
+    context.log.info(`Diff is too large: ${size}/${MAX_SIZE}`)
+    return
   }
 
   return diff.data

--- a/lib/utils/get-diff.js
+++ b/lib/utils/get-diff.js
@@ -1,4 +1,23 @@
-const MAX_SIZE = 1000000
+/**
+ * This value will take some tweaking. A really large diff
+ * is in the hundred thousands (288421 prompted this change).
+ */
+const MAX_DIFF_SIZE = 100000
+
+async function getCommit (context, method = 'GET') {
+  if (context.event === 'push') {
+    return context.github.repos.getCommit(context.repo({
+      method,
+      sha: context.payload.head_commit.id,
+      headers: { Accept: 'application/vnd.github.diff' }
+    }))
+  } else {
+    return context.github.pulls.get(context.issue({
+      method,
+      headers: { Accept: 'application/vnd.github.diff' }
+    }))
+  }
+}
 
 /**
  * Gets the diff of the commit or pull request as a string
@@ -6,24 +25,13 @@ const MAX_SIZE = 1000000
  * @returns {string}
  */
 module.exports = async context => {
-  let diff
-
-  if (context.event === 'push') {
-    diff = await context.github.repos.getCommit(context.repo({
-      sha: context.payload.head_commit.id,
-      headers: { Accept: 'application/vnd.github.diff' }
-    }))
-  } else {
-    diff = await context.github.pulls.get(context.issue({
-      headers: { Accept: 'application/vnd.github.diff' }
-    }))
-  }
-
-  const size = diff.data.length
-  if (size > MAX_SIZE) {
-    context.log.info(`Diff is too large: ${size}/${MAX_SIZE}`)
+  const headRequest = await getCommit(context, 'HEAD')
+  const diffSize = headRequest.headers['content-length']
+  if (diffSize > MAX_DIFF_SIZE) {
+    context.log.info(`Diff is too large: ${diffSize}/${MAX_DIFF_SIZE}`)
     return
   }
 
+  const diff = await getCommit(context)
   return diff.data
 }

--- a/lib/utils/main-loop.js
+++ b/lib/utils/main-loop.js
@@ -9,18 +9,17 @@ const generateLabel = require('./generate-label')
 module.exports = async (context, handler) => {
   context.todos = []
 
-  let configFile, diff
+  // Get the diff for this commit or PR
+  let diff
   try {
-    [configFile, diff] = await Promise.all([
-      // Grab the config file
-      context.config('config.yml'),
-      // Get the diff for this commit or PR
-      getDiff(context)
-    ])
+    diff = await getDiff(context)
   } catch (err) {
-    context.log.error(err)
+    context.log.info(err)
     return
   }
+
+  // Grab the config file
+  const configFile = await context.config('config.yml')
 
   const config = await configSchema.validate(configFile && configFile.todo ? configFile.todo : {})
   const keywords = Array.isArray(config.keyword) ? config.keyword : [config.keyword]

--- a/lib/utils/main-loop.js
+++ b/lib/utils/main-loop.js
@@ -9,12 +9,18 @@ const generateLabel = require('./generate-label')
 module.exports = async (context, handler) => {
   context.todos = []
 
-  const [configFile, diff] = await Promise.all([
-    // Grab the config file
-    context.config('config.yml'),
-    // Get the diff for this commit or PR
-    getDiff(context)
-  ])
+  let configFile, diff
+  try {
+    [configFile, diff] = await Promise.all([
+      // Grab the config file
+      context.config('config.yml'),
+      // Get the diff for this commit or PR
+      getDiff(context)
+    ])
+  } catch (err) {
+    context.log.error(err)
+    return
+  }
 
   const config = await configSchema.validate(configFile && configFile.todo ? configFile.todo : {})
   const keywords = Array.isArray(config.keyword) ? config.keyword : [config.keyword]

--- a/lib/utils/main-loop.js
+++ b/lib/utils/main-loop.js
@@ -10,13 +10,8 @@ module.exports = async (context, handler) => {
   context.todos = []
 
   // Get the diff for this commit or PR
-  let diff
-  try {
-    diff = await getDiff(context)
-  } catch (err) {
-    context.log.info(err)
-    return
-  }
+  const diff = await getDiff(context)
+  if (!diff) return
 
   // Grab the config file
   const configFile = await context.config('config.yml')

--- a/tests/helpers.js
+++ b/tests/helpers.js
@@ -5,7 +5,8 @@ const plugin = require('..')
 
 const loadDiff = exports.loadDiff = filename => {
   return Promise.resolve({
-    data: fs.readFileSync(path.join(__dirname, 'fixtures', 'diffs', filename + '.txt'), 'utf8')
+    data: fs.readFileSync(path.join(__dirname, 'fixtures', 'diffs', filename + '.txt'), 'utf8'),
+    headers: { 'content-length': 1 }
   })
 }
 

--- a/tests/lib/main-loop.test.js
+++ b/tests/lib/main-loop.test.js
@@ -54,7 +54,7 @@ describe('main-loop', () => {
   })
 
   it('does nothing if a title is only whitespace', async () => {
-    context.github.repos.getCommit.mockReturnValueOnce(Promise.resolve(loadDiff('title-with-whitespace')))
+    context.github.repos.getCommit.mockReturnValue(Promise.resolve(loadDiff('title-with-whitespace')))
     await mainLoop(context, handler)
     expect(handler).not.toHaveBeenCalled()
   })

--- a/tests/pull-request-handler.test.js
+++ b/tests/pull-request-handler.test.js
@@ -39,19 +39,19 @@ describe('pull-request-handler', () => {
   })
 
   it('creates many (5) comments', async () => {
-    github.pulls.get.mockReturnValueOnce(loadDiff('many'))
+    github.pulls.get.mockReturnValue(loadDiff('many'))
     await app.receive(event)
     expect(github.issues.createComment).toHaveBeenCalledTimes(5)
   })
 
   it('ignores changes to the config file', async () => {
-    github.pulls.get.mockReturnValueOnce(loadDiff('config'))
+    github.pulls.get.mockReturnValue(loadDiff('config'))
     await app.receive(event)
     expect(github.issues.createComment).not.toHaveBeenCalled()
   })
 
   it('ignores changes to the bin directory', async () => {
-    github.pulls.get.mockReturnValueOnce(loadDiff('bin'))
+    github.pulls.get.mockReturnValue(loadDiff('bin'))
     github.repos.getContents.mockReturnValueOnce(loadConfig('excludeBin'))
     await app.receive(event)
     expect(github.issues.createComment).not.toHaveBeenCalled()
@@ -64,7 +64,7 @@ describe('pull-request-handler', () => {
   })
 
   it('creates a comment with a body line', async () => {
-    github.pulls.get.mockReturnValueOnce(loadDiff('body'))
+    github.pulls.get.mockReturnValue(loadDiff('body'))
     await app.receive(event)
     expect(github.issues.createComment.mock.calls[0]).toMatchSnapshot()
   })

--- a/tests/pull-request-merge-handler.test.js
+++ b/tests/pull-request-merge-handler.test.js
@@ -30,7 +30,7 @@ describe('pull-request-merged-handler', () => {
   })
 
   it('creates an issue with a truncated title', async () => {
-    github.pulls.get.mockReturnValueOnce(loadDiff('long-title'))
+    github.pulls.get.mockReturnValue(loadDiff('long-title'))
     await app.receive(event)
     expect(github.issues.create).toHaveBeenCalledTimes(1)
     expect(github.issues.create.mock.calls[0]).toMatchSnapshot()
@@ -55,7 +55,7 @@ describe('pull-request-merged-handler', () => {
   })
 
   it('does not create any issues if no todos are found', async () => {
-    github.pulls.get.mockReturnValueOnce(loadDiff('none'))
+    github.pulls.get.mockReturnValue(loadDiff('none'))
     await app.receive(event)
     expect(github.issues.create).not.toHaveBeenCalled()
   })
@@ -69,26 +69,26 @@ describe('pull-request-merged-handler', () => {
   })
 
   it('creates many (5) issues', async () => {
-    github.pulls.get.mockReturnValueOnce(loadDiff('many'))
+    github.pulls.get.mockReturnValue(loadDiff('many'))
     await app.receive(event)
     expect(github.issues.create).toHaveBeenCalledTimes(5)
   })
 
   it('ignores changes to the config file', async () => {
-    github.pulls.get.mockReturnValueOnce(loadDiff('config'))
+    github.pulls.get.mockReturnValue(loadDiff('config'))
     await app.receive(event)
     expect(github.issues.create).not.toHaveBeenCalled()
   })
 
   it('ignores changes to the bin directory', async () => {
-    github.pulls.get.mockReturnValueOnce(loadDiff('bin'))
+    github.pulls.get.mockReturnValue(loadDiff('bin'))
     github.repos.getContents.mockReturnValueOnce(loadConfig('excludeBin'))
     await app.receive(event)
     expect(github.issues.createComment).not.toHaveBeenCalled()
   })
 
   it('creates an issue with a body line', async () => {
-    github.pulls.get.mockReturnValueOnce(loadDiff('body'))
+    github.pulls.get.mockReturnValue(loadDiff('body'))
     await app.receive(event)
     expect(github.issues.create.mock.calls[0]).toMatchSnapshot()
   })

--- a/tests/push-handler.test.js
+++ b/tests/push-handler.test.js
@@ -155,4 +155,10 @@ describe('push-handler', () => {
     await app.receive(event)
     expect(github.issues.create.mock.calls[0]).toMatchSnapshot()
   })
+
+  it('does nothing with a diff over the max size', async () => {
+    github.repos.getCommit.mockReturnValueOnce(Promise.resolve({ data: { length: 2000001 } }))
+    await app.receive(event)
+    expect(github.issues.create).not.toHaveBeenCalled()
+  })
 })

--- a/tests/push-handler.test.js
+++ b/tests/push-handler.test.js
@@ -18,7 +18,7 @@ describe('push-handler', () => {
   })
 
   it('creates an issue with a truncated title', async () => {
-    github.repos.getCommit.mockReturnValueOnce(loadDiff('long-title'))
+    github.repos.getCommit.mockReturnValue(loadDiff('long-title'))
     await app.receive(event)
     expect(github.issues.create).toHaveBeenCalledTimes(1)
     expect(github.issues.create.mock.calls[0]).toMatchSnapshot()
@@ -43,7 +43,7 @@ describe('push-handler', () => {
   })
 
   it('does not create any issues if no todos are found', async () => {
-    github.repos.getCommit.mockReturnValueOnce(loadDiff('none'))
+    github.repos.getCommit.mockReturnValue(loadDiff('none'))
     await app.receive(event)
     expect(github.issues.create).not.toHaveBeenCalled()
   })
@@ -62,7 +62,7 @@ describe('push-handler', () => {
   })
 
   it('does not create the same issue twice in the same run', async () => {
-    github.repos.getCommit.mockReturnValueOnce(loadDiff('duplicate'))
+    github.repos.getCommit.mockReturnValue(loadDiff('duplicate'))
     await app.receive(event)
     expect(github.issues.create).toHaveBeenCalledTimes(1)
   })
@@ -76,20 +76,20 @@ describe('push-handler', () => {
   })
 
   it('creates many (5) issues', async () => {
-    github.repos.getCommit.mockReturnValueOnce(loadDiff('many'))
+    github.repos.getCommit.mockReturnValue(loadDiff('many'))
     await app.receive(event)
     expect(github.issues.create).toHaveBeenCalledTimes(5)
     expect(github.issues.create.mock.calls).toMatchSnapshot()
   })
 
   it('ignores changes to the config file', async () => {
-    github.repos.getCommit.mockReturnValueOnce(loadDiff('config'))
+    github.repos.getCommit.mockReturnValue(loadDiff('config'))
     await app.receive(event)
     expect(github.issues.create).not.toHaveBeenCalled()
   })
 
   it('ignores changes to the bin directory', async () => {
-    github.repos.getCommit.mockReturnValueOnce(loadDiff('bin'))
+    github.repos.getCommit.mockReturnValue(loadDiff('bin'))
     github.repos.getContents.mockReturnValueOnce(loadConfig('excludeBin'))
     await app.receive(event)
     expect(github.issues.create).not.toHaveBeenCalled()
@@ -110,13 +110,13 @@ describe('push-handler', () => {
   })
 
   it('creates an issue with a body line', async () => {
-    github.repos.getCommit.mockReturnValueOnce(loadDiff('body'))
+    github.repos.getCommit.mockReturnValue(loadDiff('body'))
     await app.receive(event)
     expect(github.issues.create.mock.calls[0]).toMatchSnapshot()
   })
 
   it('creates an issue with a body line with one body keyword', async () => {
-    github.repos.getCommit.mockReturnValueOnce(loadDiff('body'))
+    github.repos.getCommit.mockReturnValue(loadDiff('body'))
     github.repos.getContents.mockReturnValueOnce(loadConfig('bodyString'))
     await app.receive(event)
     expect(github.issues.create.mock.calls[0]).toMatchSnapshot()
@@ -151,13 +151,13 @@ describe('push-handler', () => {
   })
 
   it('cuts the blobLines', async () => {
-    github.repos.getCommit.mockReturnValueOnce(loadDiff('blob-past-end'))
+    github.repos.getCommit.mockReturnValue(loadDiff('blob-past-end'))
     await app.receive(event)
     expect(github.issues.create.mock.calls[0]).toMatchSnapshot()
   })
 
   it('does nothing with a diff over the max size', async () => {
-    github.repos.getCommit.mockReturnValueOnce(Promise.resolve({ data: { length: 2000001 } }))
+    github.repos.getCommit.mockReturnValue(Promise.resolve({ headers: { 'content-length': 2000001 } }))
     await app.receive(event)
     expect(github.issues.create).not.toHaveBeenCalled()
   })


### PR DESCRIPTION
I believe this to be the root cause of #189 ! Large diffs were taking down the app. I noticed one in particular that was 4mb large - that was causing issues. Upon some digging, that diff turned out to be the addition of one huge file called `vendor.js` - we really don't need to be scanning files like that, or minified files in general.

~As a temporary measure, I've made it check the length of the diff against a max size of 1,000,000 characters.~

~It'd be great to do a timeout on the request itself, so if the payload is gigantic it'll just timeout. This above method still tries to download the whole payload which could be too large. I'm not sure if that's a built-in thing - @gr2m :wave: any ideas?~

I got some wonderful guidance from GitHub's API team who suggested a `HEAD` request to get the `content-length`! This works great, and avoids having to download the big diff.