### PR TITLE
Fixing regex identify keyword in terms of another languages.

### DIFF
--- a/lib/utils/main-loop.js
+++ b/lib/utils/main-loop.js
@@ -28,7 +28,7 @@ module.exports = async (context, handler) => {
   const labels = await generateLabel(context, config)
 
   // RegEx that matches lines with the configured keywords
-  const regex = new RegExp(`.*(?<keyword>${keywords.join('|')})\\s?:?(?<title>.*)`)
+  const regex = new RegExp(`(\\s|^)(?<keyword>${keywords.join('|')})(\\s)?:?(?<title>.*)`)
 
   // Parse the diff as files
   const files = parseDiff(diff)

--- a/tests/fixtures/diffs/terms-another-language.txt
+++ b/tests/fixtures/diffs/terms-another-language.txt
@@ -1,0 +1,22 @@
+diff --git a/.travis.yml b/.travis.yml
+index 0d43cbb..4e652e9 100644
+--- a/.travis.yml
++++ b/.travis.yml
+@@ -4,21 +4,22 @@
+language: node_js
+
+ node_js:
+   - "8"
+-
++
+ notifications:
+   disabled: true
+-
++ // METODO PAGO
+ branches:
+   except:
+     - /^vd+.d+.d+$/
+-
+ script:
+   - npm test
+   - codecov

--- a/tests/push-handler.test.js
+++ b/tests/push-handler.test.js
@@ -48,6 +48,12 @@ describe('push-handler', () => {
     expect(github.issues.create).not.toHaveBeenCalled()
   })
 
+  it('does not create any issues if no todos are found in terms of another language', async () => {
+    github.repos.getCommit.mockReturnValue(loadDiff('terms-another-language'))
+    await app.receive(event)
+    expect(github.issues.create).not.toHaveBeenCalled()
+  })
+
   it('does not create any issues if the push is not on the default branch', async () => {
     await app.receive({ name: 'push', payload: { ...pushEvent, ref: 'not-master' } })
     expect(github.issues.create).not.toHaveBeenCalled()


### PR DESCRIPTION
We are having trouble using terms or words in other languages.

For example: If we implement some code comment that contains the word `METODO PAGO` in Spanish, the bot identifies and creates an issue.