### PR TITLE
Trigger CI for PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,10 @@
 name: Node CI
 
-on: [push]
+on:
+  push:
+  pull_request:
+    branches:
+    - master
 
 jobs:
   build:


### PR DESCRIPTION
I noticed that CI isn't triggering for PRs from forks, because the Actions workflow is set to only trigger on `push`.