### PR TITLE
Eliminated warning

### DIFF
--- a/bin/todo.js
+++ b/bin/todo.js
@@ -81,7 +81,7 @@ async function getPull () {
   })
 })
   .catch(e => {
-    if (e.code === 404) {
+    if (e.status === 404) {
       console.error('That combination of owner/repo/sha could not be found.')
     } else {
       console.error(e)


### PR DESCRIPTION
This addressed the following warning:

```
Deprecation: [@octokit/request-error] `error.code` is deprecated, use `error.status`.
    at RequestError.get (/Users/jonasbn/develop/github-forks/todo/node_modules/@octokit/request-error/dist-node/index.js:29:17)
    at /Users/jonasbn/develop/github-forks/todo/bin/todo.js:84:11 {
  name: 'Deprecation'
```
